### PR TITLE
Corrected example typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ components/
 ```js
 import '@trendmicro/react-buttons/dist/react-buttons.css';
 
-export { Button, ButtonGroup, ButtonToolbar } from '@trendmicro/react-buttons';
+import { Button, ButtonGroup, ButtonToolbar } from '@trendmicro/react-buttons';
 ```
 
 Then, import `Button` component in your code:


### PR DESCRIPTION
The example uses the `export` keyword to import the dependencies. This PR corrects the typo.